### PR TITLE
Using epsilon check for non-decimal but rational probabilities.

### DIFF
--- a/include/AIToolbox/Utils.hpp
+++ b/include/AIToolbox/Utils.hpp
@@ -2,6 +2,7 @@
 #define AI_TOOLBOX_UTILS_HEADER_FILE
 
 #include <stddef.h>
+#include <cmath>
 
 namespace AIToolbox {
     /**
@@ -65,7 +66,7 @@ namespace AIToolbox {
                 for ( size_t j = 0; j < d2; ++j ) {
                     p += in[i][j][x];
                 }
-                if ( p != 1.0 ) return false;
+                if ( fabs(p - 1.0) > 0.000001 ) return false;
             }
         }
         return true;


### PR DESCRIPTION
It may be better to check with an epsilon if the probabilities are rational but not decimal because of the precision error.
You can change the epsilon (`0.0000001`) at will if it is not sufficient for you.
