### PR TITLE
Added Eigen3 version 3.3 as a REQUIRED component in Cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required (VERSION 3.0)
 find_package(Boost 1.53 REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
-find_package(Eigen3 3.2 REQUIRED)
+find_package(Eigen3 3.3 REQUIRED)
 include_directories(${EIGEN3_INCLUDE_DIR})
 
 if (MAKE_PYTHON)


### PR DESCRIPTION
Right now, Eigen 3.3 is required, but `cmake` does not look for 3.3. I just changed the `CMakeLists.txt` in order to fix this.