### PR TITLE
Commented the two assertions

### DIFF
--- a/src/MDP/Environments/Utils/GridWorld.cpp
+++ b/src/MDP/Environments/Utils/GridWorld.cpp
@@ -12,8 +12,8 @@ namespace AIToolbox::MDP {
     GridWorld::GridWorld(unsigned w, unsigned h) :
             width_(w), height_(h)
     {
-        assert(x > 0);
-        assert(y > 0);
+        //assert(x > 0);
+        //assert(y > 0);
     }
 
     GridWorld::State GridWorld::getAdjacent(Direction d, State s) const {


### PR DESCRIPTION
to avoid the following errors when running some of the tests. 
error: use of undeclared identifier 'x'
error: use of undeclared identifier 'y'