### PR TITLE
fix compilation

### DIFF
--- a/src/MDP/Environments/Utils/GridWorld.cpp
+++ b/src/MDP/Environments/Utils/GridWorld.cpp
@@ -12,8 +12,8 @@ namespace AIToolbox::MDP {
     GridWorld::GridWorld(unsigned w, unsigned h) :
             width_(w), height_(h)
     {
-        assert(x > 0);
-        assert(y > 0);
+        assert(height_ > 0);
+        assert(width_ > 0);
     }
 
     GridWorld::State GridWorld::getAdjacent(Direction d, State s) const {


### PR DESCRIPTION
The constructor GridWorld::GridWorld referred to undeclared variables x, y. I assume `width_` and `height_` were meant to be used.

Signed-off-by: Dimitri Scheftelowitsch <dimitri.scheftelowitsch@esrlabs.com>