### PR TITLE
Updated for compilation with multiple g++ and C++20 while resolving e…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,10 +102,12 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 ##############################
 ## Compiler/Linker Settings ##
 ##############################
-
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a")
+set(CMAKE_CXX_COMPILER g++-10)
+
 
 if (NOT WIN32)
     add_definitions(

--- a/src/Factored/Bandit/Policies/MARMaxPolicy.cpp
+++ b/src/Factored/Bandit/Policies/MARMaxPolicy.cpp
@@ -19,9 +19,9 @@ namespace AIToolbox::Factored::Bandit {
         // m >= ln(2/delta) * sum(range^2) / 2 * eps^2 * sum(range)^2
         {
             double sumR = 0.0, sumRSquared = 0.0;
-            for (auto r : ranges_) {
-                sumR += r;
-                sumRSquared += r * r;
+            for (int i = 0; i < ranges_.size(); i++) {
+                sumR += ranges_[i];
+                sumRSquared += ranges_[i] * ranges_[i];
             }
             m_ = std::max(
                 1.0,


### PR DESCRIPTION
Updated for compilation with multiple g++ and C++20 while resolving error in MARMaxPolicy.cpp for ranges_ vector

elementary edits for compilation on ubuntu 20.04 with multiple g++ installations and 9.4.0 set as default, this causes an error in MARMaxPolicy.cpp for ranges_ vector where iterating using (auto r : ranges_) is not feasible for some reason. 